### PR TITLE
Add key before adding repository URL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
-- name: Setup apt source
-  apt_repository:
-    repo: 'deb http://packages.rapidloop.com/debian stable main'
-    state: present
-
 - name: Setup apt key
   apt_key:
     keyserver: pgp.mit.edu
     id: 1E1BACF5
+
+- name: Setup apt source
+  apt_repository:
+    repo: 'deb http://packages.rapidloop.com/debian stable main'
+    state: present
 
 - name: Install agent package
   apt:


### PR DESCRIPTION
On Ubuntu Bionic Beaver (18.04) and onwards, the package cache is updated automatically after an `add-apt-repository`. This is the default behaviour, unless explicitly forbidden with the `--no-update` flag. This leads to the playbook erroring out with -

```Traceback (most recent call last):\r\n  File \"/tmp/ansible_NkRFXm/ansible_module_apt_repository.py\", line 551, in <module>\r\n    main()\r\n  File \"/tmp/ansible_NkRFXm/ansible_module_apt_repository.py\", line 543, in main\r\n    cache.update()\r\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 543, in update\r\n    raise FetchFailedException(e)\r\napt.cache.FetchFailedException: W:GPG error: http://packages.rapidloop.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C001E0681E1BACF5, E:The repository 'http://packages.rapidloop.com/debian stable InRelease' is not signed.\r\n```

This error can be circumvented by adding the public key before adding the repository. Since these actions (adding a key and adding a repository URL) are not dependent on each other unless the package cache is updated, this should preserve backward compatibility with older Debian/Ubuntu/Mint releases.